### PR TITLE
fix: MV3 service worker registration and reliable problem-data display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Kiro local machine settings (MCP config with machine-specific paths)
+.kiro/settings/

--- a/.kiro/specs/leetsage-phase1-gemini/design.md
+++ b/.kiro/specs/leetsage-phase1-gemini/design.md
@@ -1,0 +1,85 @@
+# LeetSage Phase 1 — Design
+
+## Architecture Overview
+
+Phase 1 keeps the existing extension architecture (content script → background worker → side panel, communicating via messages + Chrome storage) and layers on:
+
+- A **Gemini-backed LLM service** (OpenAI-compatible endpoint).
+- A **rate-limiter / usage-tracker service** for free-tier guardrails.
+- A **redesigned chat-hybrid side-panel UI** with theming.
+
+The pull-based problem-data flow (side panel requests `REQUEST_PROBLEM_DATA` from the content script) is already working and is preserved.
+
+## Components
+
+### 1. LLM Service (`src/services/llm-service.ts`) — modified
+- Base URL: `https://generativelanguage.googleapis.com/v1beta/openai/`
+- Auth: `Authorization: Bearer <geminiApiKey>`
+- Default model: `gemini-2.5-flash-lite`; alt: `gemini-2.5-flash`
+- Keep the streaming (SSE) generator and non-streaming paths.
+- Before every request, consult the rate limiter; abort if blocked.
+- Enforce a per-response `max_tokens` cap and a hard timeout.
+
+### 2. Rate Limiter / Usage Tracker (`src/services/rate-limiter.ts`) — new
+- Tracks request timestamps and a per-day counter, persisted in Chrome storage (survives service-worker sleep).
+- Enforces: per-minute cap, per-day cap, minimum cooldown between requests.
+- Exposes: `canMakeRequest()`, `recordRequest()`, `getUsageToday()`, and a `killSwitch` check.
+- All limits read from `UserSettings` (adjustable). Kill switch defaults off.
+- Daily counter resets at local midnight.
+
+### 3. Settings (`src/types/api.ts` UserSettings, `SettingsModal.tsx`) — modified
+- `APIConfig.provider` → `'gemini'`; add `model: 'gemini-2.5-flash-lite' | 'gemini-2.5-flash'`.
+- New guardrail settings: `maxTokens`, `maxRequestsPerMinute`, `maxRequestsPerDay`, `cooldownMs`, `requestTimeoutMs`, `killSwitch`.
+- New `theme: 'light' | 'dark'` (default `'dark'`).
+- Gemini key validation (Gemini keys typically start with `AIza`).
+
+### 4. Chat-Hybrid UI (`src/sidepanel/App.tsx`, components) — redesigned
+- Primary surface: a single text input at the bottom (chat-style).
+- Above/around it: the 7 actions as compact **quick-command chips**.
+- Responses stream into **structured hint cards** (reusing existing card styling, decluttered).
+- A slim header with usage counter ("X/Y today"), theme toggle, and settings gear.
+- Dark theme by default; theme applied via a root class + Tailwind `dark:` variants or CSS variables.
+
+### 5. Icon-Click Fix (`src/background/index.ts`, `public/manifest.json`)
+- Diagnose via service-worker console. Confirm `setPanelBehavior` result.
+- Keep the documented pattern; if environmental, document right-click / keyboard as the definitive method and ensure at least one reliable path.
+
+## Data Model Additions
+
+```
+UserSettings {
+  apiConfig: { provider: 'gemini'; apiKey: string; model: 'gemini-2.5-flash-lite' | 'gemini-2.5-flash' }
+  theme: 'light' | 'dark'
+  guardrails: {
+    maxTokens: number            // e.g. 800
+    maxRequestsPerMinute: number // e.g. 8
+    maxRequestsPerDay: number    // e.g. 200 (generous, under free tier)
+    cooldownMs: number           // e.g. 2000
+    requestTimeoutMs: number     // e.g. 20000
+    killSwitch: boolean          // default false
+  }
+}
+
+UsageState (storage key: usage_YYYY-MM-DD) {
+  date: string
+  count: number
+  recentTimestamps: number[]   // for per-minute window
+}
+```
+
+## Guardrail Defaults (generous but safe)
+
+| Setting | Default | Rationale |
+|---|---|---|
+| maxTokens | 800 | Plenty for a hint; caps runaway responses |
+| maxRequestsPerMinute | 8 | Under Flash-Lite's ~15/min |
+| maxRequestsPerDay | 200 | Under Flash-Lite's ~1000/day, generous for personal use |
+| cooldownMs | 2000 | Prevents rapid-fire/stuck loops |
+| requestTimeoutMs | 20000 | Nothing hangs |
+| killSwitch | false | Off by default; instant stop when needed |
+
+## Testing Strategy
+
+- Build must compile clean (`npm.cmd run build`).
+- Manual end-to-end test in the user's real Chrome (MCP can't host the extension).
+- Verify: icon/right-click opens panel → problem shows → type or tap chip → real Gemini hint streams in → solution filter applied → usage counter increments → exceeding a test limit blocks gracefully → theme toggle persists.

--- a/.kiro/specs/leetsage-phase1-gemini/requirements.md
+++ b/.kiro/specs/leetsage-phase1-gemini/requirements.md
@@ -1,0 +1,48 @@
+# LeetSage Phase 1 — Working Free-Tier Base (Gemini)
+
+## Problem Statement
+
+LeetSage's core pipeline works (problem extraction → side panel display), but the AI never actually responds because there's no LLM wired to a usable free provider. The UI is cluttered and unstyled, and the toolbar-icon-click doesn't open the side panel. Phase 1 delivers a genuinely usable, good-looking tool that runs on Google Gemini's free tier, differentiated from LeetCode's built-in "Ask Leet" by a coaching (no-solutions) philosophy.
+
+## Product Identity
+
+LeetSage is a **personal, anti-cheating study coach for LeetCode** that deliberately withholds full solutions and helps the user build real understanding. It is free (bring-your-own-key), runs on Google Gemini's free tier, and is intentionally different from LeetCode's built-in "Ask Leet" (a solve-for-you Premium agent).
+
+Primary user: the developer. Then interview preppers. Then students. Not currently a commercial product.
+
+## Requirements
+
+1. **Gemini provider (free tier).** Use Google Gemini through its OpenAI-compatible endpoint. Default model `gemini-2.5-flash-lite`, switchable to `gemini-2.5-flash` in settings. No other providers surfaced in the UI.
+
+2. **Chat-hybrid side-panel UI.** One clean text input as the primary surface. The 7 existing actions become quick-command chips. Responses render as structured hint cards. Coaching feel, not a generic chatbot.
+
+3. **Manual light/dark theme toggle**, defaulting to dark.
+
+4. **Free-tier guardrails, generous and adjustable.** Per-response token cap, local per-minute + per-day rate limiter (stricter than Gemini's), cooldown between requests, hard request timeout, visible "X/Y requests today" usage counter, and a kill switch (off by default). All limits configurable in settings.
+
+5. **Toolbar-icon-click opens the side panel** (or a documented, definitive fallback if it proves environmental).
+
+6. **Preserve the no-solution philosophy** — the existing solution filter and problem-extraction pipeline stay intact.
+
+## Key Architectural Decision — Bring-Your-Own-Key (BYOK)
+
+Phase 1 uses BYOK (each user supplies their own Gemini key) rather than a supplied/managed key.
+
+- **A client-side extension cannot hide a secret.** A hardcoded key ships to every user's machine and can be extracted in seconds → key theft, bill abuse, or instant free-quota exhaustion that breaks the app for everyone.
+- **A managed key requires a backend server** (browser → your server → Gemini) to keep the key server-side — introducing hosting costs, per-user usage bills, abuse protection, uptime, and a data-privacy surface.
+- **BYOK fits the current reality:** primary user is the developer (already has a key), no users yet, not selling it. Each user gets their own free Gemini quota, so N users = N free allowances at zero cost/liability.
+- **Tradeoff:** BYOK adds setup friction (user must fetch a free key), acceptable for a technical audience. If LeetSage ever gains non-technical users at scale, revisit with a managed backend — likely a subsidized free allowance plus a BYOK-for-unlimited hybrid. That's a post-demand decision, not a now decision.
+
+## Research Findings
+
+- Gemini free tier requires no billing/credit card; over-limit requests are rejected (HTTP 429), not billed — the strongest possible cost ceiling.
+- Free limits (early 2026): Flash-Lite ~15 req/min, ~1,000/day; Flash ~10 req/min, ~250/day.
+- OpenAI-compatible base URL: `https://generativelanguage.googleapis.com/v1beta/openai/` — the existing `src/services/llm-service.ts` (OpenAI chat-completions format) needs minimal change.
+- The icon-click uses the documented-correct pattern (`side_panel.default_path` in manifest + `setPanelBehavior({openPanelOnActionClick:true})` in the background worker), so the failure is likely environmental.
+
+## Out of Scope (Future Phases)
+
+- **Phase 2:** Tiered "state your approach first" struggle-first flow (explain your reasoning to unlock deeper hints).
+- **Phase 3:** Learning analytics — hints used, solution-reveal tracking, time spent, submission success/failure, and flagging problems to revisit.
+- Cross-platform support (HackerRank, Codeforces, etc.) — someday-maybe, LeetCode-only for now.
+- Managed-key backend — only if/when there's real non-technical user demand.

--- a/docs/leetsage-learning-guide.md
+++ b/docs/leetsage-learning-guide.md
@@ -1,0 +1,687 @@
+# LeetSage: Deep Dive Learning Guide
+
+This document is maintained alongside implementation. Each section explains *what* was built, *why* it was built that way, and *how* it works. Use this as your reference for understanding the codebase.
+
+---
+
+## Table of Contents
+1. [Project Overview](#1-project-overview)
+2. [Chrome Extension Architecture](#2-chrome-extension-architecture)
+3. [Data Flow](#3-data-flow)
+4. [TypeScript Types](#4-typescript-types)
+5. [Content Script & DOM Extraction](#5-content-script--dom-extraction)
+6. [Background Service Worker](#6-background-service-worker)
+7. [Chrome Storage](#7-chrome-storage)
+8. [Progress Tracker](#8-progress-tracker)
+9. [LLM Service](#9-llm-service)
+10. [System Prompts](#10-system-prompts)
+11. [Solution Filter](#11-solution-filter)
+12. [Hint System](#12-hint-system)
+13. [Example Generator & Breakdown Engine](#13-example-generator--breakdown-engine)
+14. [React Side Panel](#14-react-side-panel)
+15. [Action Panel Component](#15-action-panel-component)
+16. [Content Display Component](#16-content-display-component)
+17. [Settings Modal](#17-settings-modal)
+18. [Chat Mode](#18-chat-mode)
+19. [Stuck Timer](#19-stuck-timer)
+20. [Build & Development Workflow](#20-build--development-workflow)
+
+---
+
+## 1. Project Overview
+
+LeetSage is a Chrome extension that acts as an AI-powered learning companion for LeetCode. When you're on a problem page, it opens a side panel with action buttons that trigger AI-generated learning aids — hints, examples, breakdowns — without ever giving you the complete answer.
+
+**Core philosophy:** Help you *understand* the problem, not solve it for you.
+
+**Tech stack:**
+- React 19 + TypeScript 5.8 (UI)
+- Tailwind CSS 4 (styling)
+- Vite 7 (build tool)
+- Chrome Extension Manifest V3
+- OpenAI API / Anthropic API (LLM)
+
+---
+
+## 2. Chrome Extension Architecture
+
+A Chrome extension has three separate JavaScript execution contexts. They cannot share memory — they communicate only via messages and Chrome Storage.
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   LeetCode Page                      │
+│  ┌──────────────────────────────────────────────┐   │
+│  │  Content Script (src/content/)               │   │
+│  │  - Runs inside the webpage                   │   │
+│  │  - Can read/modify LeetCode's DOM            │   │
+│  │  - Extracts problem title, difficulty, etc.  │   │
+│  │  - Sends PROBLEM_DATA message                │   │
+│  └──────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────┘
+         │ chrome.runtime.sendMessage
+         ▼
+┌─────────────────────────────────────────────────────┐
+│  Background Service Worker (src/background/)         │
+│  - Runs independently of any page                   │
+│  - Has full Chrome API access                       │
+│  - Routes messages between contexts                 │
+│  - Reads/writes Chrome Storage                      │
+│  - Handles keyboard shortcuts                       │
+└─────────────────────────────────────────────────────┘
+         │ chrome.storage.local
+         ▼
+┌─────────────────────────────────────────────────────┐
+│  Side Panel UI (src/sidepanel/)                      │
+│  - React app running in Chrome's side panel         │
+│  - Reads problem data from Chrome Storage           │
+│  - Calls LLM API directly                           │
+│  - Displays action buttons and learning content     │
+└─────────────────────────────────────────────────────┘
+```
+
+**Why this separation?**
+- Content scripts can access the page DOM but not Chrome APIs
+- Background workers have Chrome API access but no DOM
+- UI pages have both but can't access the *webpage's* DOM
+- This is a security boundary Chrome enforces
+
+---
+
+## 3. Data Flow
+
+### Problem Detection Flow
+```
+User navigates to leetcode.com/problems/two-sum/
+  → Content script runs
+  → Waits for DOM elements to load (LeetCode is a React SPA)
+  → Extracts: title, difficulty, description, examples, constraints
+  → Sends PROBLEM_DATA message to background worker
+  → Background worker saves to Chrome Storage
+  → Side panel reads from Chrome Storage on mount
+```
+
+### Action Button Flow
+```
+User clicks "Get Hint"
+  → ActionPanel calls handleActionClick('GET_HINT')
+  → App retrieves problem context from state
+  → LLM Service builds request with system prompt + problem context
+  → Calls OpenAI API
+  → Response streams back
+  → Solution Filter checks for complete solutions
+  → Filtered content rendered in ContentDisplay
+  → Progress Tracker records 'GET_HINT' was used
+  → Chrome Storage updated with new progress
+```
+
+---
+
+## 4. TypeScript Types
+
+**File:** `src/types/`
+
+Types are the backbone of the app. Defining them first means every service and component knows exactly what shape data should be.
+
+### Key types:
+
+**`ProblemContext`** — Everything extracted from a LeetCode page:
+```typescript
+{
+  title: "1. Two Sum",
+  url: "https://leetcode.com/problems/two-sum/",
+  difficulty: "Easy",
+  description: "Given an array of integers...",
+  examples: [{ input: "nums = [2,7,11,15]", output: "[0,1]" }],
+  constraints: ["2 <= nums.length <= 10^4"],
+  testCases: [...],
+  extractedAt: 1712345678000
+}
+```
+
+**`ActionType`** — The 7 action buttons:
+```typescript
+'GET_HINT' | 'GENERATE_EXAMPLES' | 'BREAK_DOWN_PROBLEM' |
+'EXPLAIN_CONCEPT' | 'CHECK_APPROACH' | 'TIME_COMPLEXITY_HINT' | 'PATTERN_RECOGNITION'
+```
+
+**`LearningContent`** — AI-generated content displayed to user:
+```typescript
+{
+  id: "abc123",
+  type: "HINT",
+  actionType: "GET_HINT",
+  content: "## Hint 1\nThink about what data structure...",
+  timestamp: 1712345678000,
+  expanded: true,
+  metadata: { hintLevel: 1 }
+}
+```
+
+**`ProgressState`** — Per-problem tracking:
+```typescript
+{
+  problemUrl: "https://leetcode.com/problems/two-sum/",
+  usedActions: Set { 'GET_HINT', 'GENERATE_EXAMPLES' },
+  hintLevel: 1,
+  contentHistory: [...],
+  lastUpdated: 1712345678000
+}
+```
+
+**Message types** — Type-safe Chrome message passing:
+```typescript
+// Content → Background
+{ type: 'PROBLEM_DATA', payload: ProblemContext }
+
+// Side Panel → Background
+{ type: 'GET_PROBLEM_DATA', payload: { url: string } }
+{ type: 'TRACK_ACTION', payload: { problemUrl, actionType, timestamp } }
+```
+
+**Why type guards?**
+```typescript
+// Without type guard - TypeScript doesn't know the shape
+chrome.runtime.onMessage.addListener((message) => {
+  message.payload.title // ❌ Error: payload might not exist
+});
+
+// With type guard - TypeScript narrows the type
+chrome.runtime.onMessage.addListener((message) => {
+  if (isProblemDataMessage(message)) {
+    message.payload.title // ✅ TypeScript knows this is ProblemContext
+  }
+});
+```
+
+---
+
+## 5. Content Script & DOM Extraction
+
+**Files:** `src/content/index.ts`, `src/content/extractor.ts`
+
+### Why content scripts are tricky
+
+LeetCode is a React single-page app (SPA). When you navigate to a problem:
+1. The URL changes (e.g., `/problems/two-sum/`)
+2. React re-renders the page content
+3. But the browser doesn't do a full page reload
+
+This means:
+- DOM elements aren't immediately available
+- We need to *wait* for them to appear
+- We need to detect navigation changes (MutationObserver)
+
+### waitForElement pattern
+```typescript
+function waitForElement<T extends Element>(selector: string, timeout = 10000): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const startTime = Date.now();
+    const interval = setInterval(() => {
+      const el = document.querySelector<T>(selector);
+      if (el) { clearInterval(interval); resolve(el); }
+      else if (Date.now() - startTime > timeout) {
+        clearInterval(interval);
+        reject(new Error(`Timeout: ${selector}`));
+      }
+    }, 500);
+  });
+}
+```
+Polls every 500ms until the element appears or times out.
+
+### Retry with exponential backoff
+```typescript
+for (let attempt = 0; attempt < 3; attempt++) {
+  try {
+    return await extractProblemContext();
+  } catch (error) {
+    const delay = Math.pow(2, attempt) * 1000; // 1s, 2s, 4s
+    await new Promise(r => setTimeout(r, delay));
+  }
+}
+```
+If extraction fails (e.g., page still loading), wait progressively longer before retrying.
+
+### MutationObserver for SPA navigation
+```typescript
+const observer = new MutationObserver((mutations) => {
+  // Check if new problem links appeared in the DOM
+  const urlChanged = mutations.some(m =>
+    Array.from(m.addedNodes).some(n =>
+      n instanceof HTMLElement && n.querySelector('a[href^="/problems/"]')
+    )
+  );
+  if (urlChanged) callback(); // Re-extract
+});
+observer.observe(document.body, { childList: true, subtree: true });
+```
+
+---
+
+## 6. Background Service Worker
+
+**File:** `src/background/index.ts`
+
+### What it does
+Acts as the central message router and storage coordinator.
+
+### Service Worker vs Background Page
+Old extensions used a persistent background page. Manifest V3 uses a *service worker* which:
+- Starts when an event fires (message received, command triggered)
+- Stops after ~30 seconds of inactivity
+- **Cannot store state in memory** — must use Chrome Storage
+
+### Message routing pattern
+```typescript
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (isProblemDataMessage(message)) {
+    saveProblemContext(message.payload)
+      .then(() => sendResponse({ success: true }))
+      .catch(err => sendResponse({ success: false, error: err.message }));
+    return true; // ← CRITICAL: tells Chrome we'll respond asynchronously
+  }
+});
+```
+The `return true` is essential — without it, Chrome closes the message channel before your async operation completes.
+
+---
+
+## 7. Chrome Storage
+
+**File:** `src/services/storage.ts`
+
+### Why not localStorage?
+| Feature | localStorage | chrome.storage.local |
+|---------|-------------|---------------------|
+| Works in content scripts | ✅ | ✅ |
+| Works in background worker | ❌ | ✅ |
+| Works in side panel | ✅ | ✅ |
+| Async | ❌ (blocks) | ✅ |
+| Limit | 5MB | 10MB |
+
+### The Set serialization problem
+Chrome Storage uses JSON serialization. JSON doesn't support `Set`:
+```typescript
+JSON.stringify(new Set(['GET_HINT'])) // → "{}" ❌ Empty!
+```
+Solution: convert Set ↔ Array on save/load:
+```typescript
+// Saving
+const storableProgress = { ...progress, usedActions: Array.from(progress.usedActions) };
+
+// Loading
+const progress = { ...stored, usedActions: new Set(stored.usedActions) };
+```
+
+### Storage key strategy
+```typescript
+// Problem data (one at a time)
+"problemData" → ProblemContext
+
+// Progress (one per problem)
+"progress_https://leetcode.com/problems/two-sum/" → ProgressState
+
+// User settings (global)
+"userSettings" → UserSettings
+```
+
+---
+
+## 8. Progress Tracker
+
+**File:** `src/services/progress-tracker.ts`
+
+### Why a separate service?
+`storage.ts` handles *how* to persist data. `progress-tracker.ts` handles *what* to do with progress data. This separation means:
+- Business logic (hint level increment) lives in one place
+- Storage implementation can change without affecting tracker logic
+- Easier to test each piece independently
+
+### Hint level auto-increment
+```typescript
+if (actionType === 'GET_HINT') {
+  progress.hintLevel = Math.min(progress.hintLevel + 1, 3); // Max 3 hints
+}
+```
+The tracker automatically manages hint progression — the UI just calls `trackAction('GET_HINT')` and the level increments.
+
+---
+
+## 9. LLM Service
+
+**File:** `src/services/llm-service.ts`
+
+Handles all communication with the OpenAI API (or Anthropic).
+
+### Why call the API from the side panel directly?
+No backend server is needed — the user provides their own API key, stored in Chrome Storage. The side panel calls the API directly over HTTPS.
+
+### Streaming vs non-streaming
+```typescript
+// Non-streaming: waits for full response (feels slow)
+const response = await sendLLMRequest(request);
+setContent(response.content);
+
+// Streaming: shows text as it generates (feels fast and engaging)
+for await (const chunk of streamLLMRequest(request)) {
+  setContent(prev => prev + chunk);
+}
+```
+
+
+Streaming uses the [Server-Sent Events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) format. Each line from the API looks like:
+```
+data: {"choices":[{"delta":{"content":"Think"}}]}
+data: {"choices":[{"delta":{"content":" about"}}]}
+data: [DONE]
+```
+
+### Retry logic
+Network errors get 2 retries with exponential backoff (1s, 2s). Client errors (401, 429) are thrown immediately — retrying won't help.
+
+### Error types
+- `401` → Invalid API key → show settings prompt
+- `429` → Rate limited → show wait message
+- `AbortError` → Request timed out after 30s
+
+---
+
+## 10. System Prompts
+
+**File:** `src/services/prompts.ts`
+
+Each of the 7 action types has a specialized system prompt. This is what makes LeetSage's responses focused and educational rather than generic.
+
+### Why separate prompts per action?
+- `GET_HINT` needs to know about hint levels (1, 2, 3)
+- `GENERATE_EXAMPLES` needs to produce structured output with complexity labels
+- `CHECK_APPROACH` needs to review user input, not generate from scratch
+- Generic prompts produce generic responses
+
+### Solution prevention rules (in every prompt)
+```
+CRITICAL RULES:
+1. NEVER provide a complete working code solution
+2. NEVER write a full function implementation
+3. You MAY provide short snippets (<10 lines) to illustrate a concept
+4. You MAY provide pseudocode
+```
+
+### Problem context injection
+`formatProblemContext()` converts a `ProblemContext` object into a readable string that gets appended to every user message, so the AI always knows which problem it's helping with.
+
+---
+
+## 11. Solution Filter
+
+**File:** `src/services/solution-filter.ts`
+
+A post-processing layer that checks LLM responses for complete solutions.
+
+### Why two layers of protection?
+1. System prompts tell the AI not to give solutions
+2. Solution filter catches cases where the AI ignores the instruction
+
+### What gets filtered?
+- Code blocks over 20 lines
+- Responses containing "here's the complete solution", "full implementation", etc.
+- Complete function implementations (detected via regex patterns)
+
+### What's allowed?
+- Short snippets under 10 lines
+- Pseudocode
+- `CHECK_APPROACH` responses (reviewing user code is always allowed)
+
+### Filter result
+```typescript
+{ filteredContent: string, wasFiltered: boolean, filterReason?: string }
+```
+If filtered, the content is replaced with a friendly message directing the user to use hints instead.
+
+---
+
+## 12. Hint System
+
+**File:** `src/services/hint-system.ts`
+
+Manages the 3-level progressive hint system.
+
+### Hint levels
+| Level | Name | What it covers |
+|-------|------|---------------|
+| 1 | Conceptual | What kind of problem is this? What data structure might help? |
+| 2 | Approach | What strategy/algorithm? What are the steps? |
+| 3 | Implementation | Specific techniques, edge cases, tricky parts |
+
+### How level tracking works
+- `ProgressState.hintLevel` stores the current level (0 = no hints used)
+- `trackAction('GET_HINT')` increments it (max 3)
+- `generateHint(context, level, apiKey)` passes the level to the LLM prompt
+- The UI shows "All hints used" when `hintLevel >= 3`
+
+---
+
+## 13. Example Generator & Breakdown Engine
+
+**Files:** `src/services/example-generator.ts`, `src/services/breakdown-engine.ts`
+
+Both services follow the same pattern:
+1. Call `sendLLMRequest` with the appropriate `ActionType`
+2. The prompt in `prompts.ts` defines the output format
+3. Return the raw markdown — the `ContentDisplay` component renders it
+
+The LLM handles the actual generation logic. These services are thin wrappers that provide the right context.
+
+---
+
+## 14. React Side Panel
+
+**File:** `src/sidepanel/App.tsx`
+
+The root React component. Manages all global state and coordinates between components.
+
+### State overview
+```typescript
+problemContext   // What problem is the user on?
+progress         // What have they already tried?
+learningContent  // Array of AI-generated cards to display
+isLoading        // Is an API call in progress?
+settings         // API key, preferences
+stuckSuggestion  // Proactive suggestion from stuck timer
+showChat         // Is chat mode open?
+streamingId      // Which content card is currently streaming?
+```
+
+### How problem context loads
+```typescript
+useEffect(() => {
+  // 1. Load from Chrome Storage on mount
+  chrome.storage.local.get('problemData', (result) => {
+    setProblemContext(result.problemData);
+  });
+
+  // 2. Listen for updates when user navigates to a new problem
+  chrome.storage.onChanged.addListener((changes) => {
+    if (changes.problemData) setProblemContext(changes.problemData.newValue);
+  });
+}, []);
+```
+
+### The action flow (handleActionClick)
+```
+User clicks button
+  → Set isLoading = true
+  → Create empty LearningContent with unique ID
+  → Add to learningContent array (shows loading card)
+  → Stream from LLM API, updating content chunk by chunk
+  → Run solution filter on completed response
+  → Track action in progress tracker
+  → Set isLoading = false
+```
+
+### Streaming UI update
+```typescript
+for await (const chunk of streamLLMRequest(request)) {
+  fullContent += chunk;
+  // Update just the streaming card, leave others unchanged
+  setLearningContent(prev =>
+    prev.map(c => c.id === contentId ? { ...c, content: fullContent } : c)
+  );
+}
+```
+
+---
+
+## 15. Action Panel Component
+
+**File:** `src/components/ActionPanel.tsx`
+
+The primary UI — 7 action buttons in a 2-column grid.
+
+### Button states
+- Normal: colored background, clickable
+- Used: shows ✓ checkmark in top-right corner
+- Disabled: 40% opacity, not clickable (no API key, loading, or hints exhausted)
+- Loading: subtle pulse animation
+
+### Check Approach special case
+This button toggles a textarea input instead of immediately calling the LLM. The user types their approach, then submits it. This is the only action that requires user input before calling the API.
+
+### Hint level indicator
+Shows 3 circles (●●●) that fill in as hints are used. When all 3 are used, the GET_HINT button is disabled and shows "All hints used".
+
+---
+
+## 16. Content Display Component
+
+**File:** `src/components/ContentDisplay.tsx`
+
+Renders AI-generated content as expandable cards.
+
+### Custom markdown renderer
+Instead of a library, we wrote a lightweight renderer that handles:
+- `## Heading` → `<h2>`
+- `### Heading` → `<h3>`
+- `- bullet` → `<li>`
+- `` `code` `` → `<code>` with monospace font
+- ` ```code block``` ` → `<pre>` with dark background
+- `**bold**` → `<strong>`
+
+Why not use `react-markdown`? Keeps the bundle smaller and avoids a dependency for a side panel that needs to be lightweight.
+
+### Streaming cursor
+While a card is streaming, a blinking cursor `|` appears after the last character:
+```typescript
+{isStreaming && item.content && (
+  <span className="inline-block w-1 h-3 bg-gray-400 animate-pulse ml-0.5" />
+)}
+```
+
+### Auto-scroll
+```typescript
+useEffect(() => {
+  bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+}, [content.length]); // Triggers when a new card is added
+```
+
+---
+
+## 17. Settings Modal
+
+**File:** `src/components/SettingsModal.tsx`
+
+Handles API key configuration.
+
+### API key validation
+```typescript
+if (provider === 'openai' && !key.startsWith('sk-')) return 'OpenAI keys start with "sk-"';
+if (provider === 'anthropic' && !key.startsWith('sk-ant-')) return 'Anthropic keys start with "sk-ant-"';
+```
+
+### Security note
+The API key is stored in `chrome.storage.local` — it never leaves the user's browser. It's not sent to any LeetSage server (there isn't one). It's only sent directly to OpenAI/Anthropic when making API calls.
+
+---
+
+## 18. Chat Mode
+
+**File:** `src/components/ChatMode.tsx`
+
+An optional free-form chat interface, visually secondary to the action buttons.
+
+### How it differs from action buttons
+- User types a custom question instead of clicking a preset button
+- Messages appear as chat bubbles (user = blue right, assistant = gray left)
+- Same solution filter applies
+- Uses `EXPLAIN_CONCEPT` action type for the system prompt (general learning focus)
+
+### Activation
+A subtle "💬 Open free-form chat" link at the bottom of the side panel. Clicking it replaces the content display with the chat interface.
+
+---
+
+## 19. Stuck Timer
+
+**File:** `src/services/stuck-timer.ts`
+
+Proactively suggests help after 5 minutes of inactivity.
+
+### How it works
+```typescript
+const timer = new StuckTimer((suggestion) => {
+  setStuckSuggestion(suggestion); // Shows banner in UI
+}, settings.enableStuckTimer);
+
+// Start when problem loads
+timer.start(problem.difficulty);
+
+// Reset when user takes action
+timer.start(problem.difficulty); // Called after every handleActionClick
+```
+
+### Rate limiting
+```typescript
+if (now - this.lastSuggestionTime < COOLDOWN_MS) return; // 10 min cooldown
+```
+Won't spam the user — maximum one suggestion per 10 minutes.
+
+### Smart suggestions
+- Easy/Medium problems → suggest `GET_HINT`
+- Hard problems → suggest `BREAK_DOWN_PROBLEM`
+
+---
+
+## 20. Build & Development Workflow
+
+### Building the extension
+```bash
+npm run build
+```
+Vite creates the `dist/` folder with:
+- `dist/side_panel.js` — React app bundle
+- `dist/background.js` — Service worker
+- `dist/content.js` — Content script
+- `dist/manifest.json` — Extension manifest (copied from public/)
+- `dist/assets/` — CSS and other assets
+
+### Loading in Chrome
+1. Go to `chrome://extensions`
+2. Enable "Developer mode" (top right toggle)
+3. Click "Load unpacked"
+4. Select the `dist/` folder
+5. LeetSage appears in your extensions
+
+### After making code changes
+1. Run `npm run build`
+2. Click the reload icon on LeetSage in `chrome://extensions`
+3. If you changed the content script, also refresh the LeetCode tab
+
+### Debugging each context
+| Context | How to inspect |
+|---------|---------------|
+| Content script | Right-click LeetCode page → Inspect → Console (select content script context from dropdown) |
+| Background worker | `chrome://extensions` → Click "service worker" link |
+| Side panel | Right-click inside side panel → Inspect |
+
+### Viewing Chrome Storage
+DevTools → Application tab → Storage → Extension Storage → Local Storage

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@eslint/js": "^9.33.0",
         "@tailwindcss/vite": "^4.1.12",
         "@types/chrome": "^0.1.4",
+        "@types/node": "^26.4.0",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
@@ -1697,6 +1698,16 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.1.11",
@@ -4123,6 +4134,13 @@
         "node": ">=20.18.1"
       }
     },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -5355,6 +5373,15 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "@types/node": {
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~8.3.0"
+      }
     },
     "@types/react": {
       "version": "19.1.11",
@@ -6938,6 +6965,12 @@
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.15.0.tgz",
       "integrity": "sha512-7oZJCPvvMvTd0OlqWsIxTuItTpJBpU1tcbVl24FMn3xt3+VSunwUasmfPJRE57oNO1KsZ4PgA1xTdAX4hq8NyQ==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@eslint/js": "^9.33.0",
     "@tailwindcss/vite": "^4.1.12",
     "@types/chrome": "^0.1.4",
+    "@types/node": "^26.4.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",
@@ -31,5 +32,9 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
     "vite": "^7.1.2"
+  },
+  "allowScripts": {
+    "@tailwindcss/oxide@4.1.12": true,
+    "esbuild@0.25.9": true
   }
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "description": "AI-powered learning companion for LeetCode problems. Get hints, examples, and breakdowns without spoiling solutions.",
   "action": {
-    "default_popup": "index.html",
     "default_icon": "images/LeetCode_logo_black.png"
   },
   "side_panel": {
@@ -22,7 +21,8 @@
     "32": "images/LeetCode_logo_black.png"
   },
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "type": "module"
   },
   "host_permissions": ["http://*/*", "https://*/*"],
   "content_scripts": [

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -4,8 +4,34 @@ import { saveProblemContext, getProblemContext, saveProgress, getProgress, reset
 import { isProblemDataMessage, isGetProblemDataMessage, isTrackActionMessage, isGetProgressMessage, isResetProgressMessage } from '../types';
 import type { ExtensionMessage } from '../types';
 
+// Open the side panel when the user clicks the toolbar icon.
+//
+// We rely SOLELY on the native openPanelOnActionClick behavior. Chrome
+// handles this click itself, so it works even when the service worker is
+// asleep/inactive. Do NOT also register chrome.action.onClicked — having
+// both makes Chrome suppress the native open and the manual open then fails
+// because the worker cold-start loses the user-gesture context.
+function enablePanelOnActionClick() {
+  // Ensure the panel is enabled globally, THEN set the click-to-open behavior.
+  // Some Chrome builds require an explicit enabled:true before openPanelOnActionClick
+  // takes effect.
+  chrome.sidePanel
+    .setOptions({ path: 'index.html', enabled: true })
+    .then(() => chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true }))
+    .then(() => console.log('[LeetSage Background] side panel enabled + openPanelOnActionClick set'))
+    .catch((err) => console.error('[LeetSage Background] side panel setup failed:', err));
+}
+
+enablePanelOnActionClick();
+
 chrome.runtime.onInstalled.addListener(() => {
   console.log('[LeetSage Background] Service worker installed');
+  enablePanelOnActionClick();
+});
+
+chrome.runtime.onStartup.addListener(() => {
+  console.log('[LeetSage Background] Browser startup');
+  enablePanelOnActionClick();
 });
 
 chrome.runtime.onMessage.addListener((message: ExtensionMessage, _sender, sendResponse) => {

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,19 +1,49 @@
 /// <reference types="chrome"/>
 
 import { extractProblemContext, observeProblemChanges } from './extractor';
-import type { ProblemDataMessage } from '../types';
+import type { ProblemContext, ProblemDataMessage } from '../types';
+
+// Cache the most recent successful extraction so the side panel can
+// pull it on demand without waiting for a fresh extraction.
+let cachedProblem: ProblemContext | null = null;
 
 async function extractAndSendProblemData(): Promise<void> {
   try {
     const problemContext = await extractProblemContext();
+    cachedProblem = problemContext;
+
+    // Push to background/storage (best-effort — may be dropped if the
+    // service worker is asleep, which is why the side panel also pulls).
     const message: ProblemDataMessage = { type: 'PROBLEM_DATA', payload: problemContext };
     chrome.runtime.sendMessage(message, () => {
-      if (chrome.runtime.lastError) console.error('[LeetSage] Error sending message:', chrome.runtime.lastError);
+      // Swallow "no receiving end" errors — the side panel pull path covers this.
+      void chrome.runtime.lastError;
     });
   } catch (error) {
     console.error('[LeetSage] Failed to extract problem data:', error);
   }
 }
+
+// Respond to on-demand requests from the side panel. This is the reliable
+// path: the panel asks when IT is ready, sidestepping the MV3 race where
+// the service worker isn't awake when the content script first loads.
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message?.type === 'REQUEST_PROBLEM_DATA') {
+    if (cachedProblem) {
+      sendResponse({ success: true, data: cachedProblem });
+    } else {
+      // No cache yet — extract now and respond when ready.
+      extractProblemContext()
+        .then((ctx) => {
+          cachedProblem = ctx;
+          sendResponse({ success: true, data: ctx });
+        })
+        .catch((err) => sendResponse({ success: false, error: String(err) }));
+    }
+    return true; // async response
+  }
+  return false;
+});
 
 (async () => {
   await extractAndSendProblemData();

--- a/src/sidepanel/App.tsx
+++ b/src/sidepanel/App.tsx
@@ -33,25 +33,72 @@ const App: React.FC = () => {
   const [stuckSuggestion, setStuckSuggestion] = useState<StuckSuggestion | null>(null);
   const stuckTimerRef = React.useRef<StuckTimer | null>(null);
 
-  useEffect(() => {
-    chrome.storage.local.get('problemData', (result) => {
-      if (result.problemData) {
-        const ctx = result.problemData as ProblemContext;
-        setProblemContext(ctx);
-        loadProgress(ctx.url).then(p => { setProgress(p); if (p) setLearningContent(p.contentHistory); });
-      }
+  // Applies a freshly obtained problem context to state + loads its progress.
+  const applyProblem = useCallback((ctx: ProblemContext) => {
+    setProblemContext(prev => {
+      // If it's a different problem, clear the transient content.
+      if (!prev || prev.url !== ctx.url) setLearningContent([]);
+      return ctx;
     });
-    const listener = (changes: Record<string, chrome.storage.StorageChange>) => {
-      if (changes.problemData?.newValue) {
-        const ctx = changes.problemData.newValue as ProblemContext;
-        setProblemContext(ctx);
-        setLearningContent([]);
-        loadProgress(ctx.url).then(p => { setProgress(p); if (p) setLearningContent(p.contentHistory); });
-      }
-    };
-    chrome.storage.onChanged.addListener(listener);
-    return () => chrome.storage.onChanged.removeListener(listener);
+    loadProgress(ctx.url).then(p => { setProgress(p); if (p) setLearningContent(p.contentHistory); });
   }, []);
+
+  // Pull problem data directly from the active tab's content script.
+  // This is the reliable path — the panel asks when it's ready, avoiding
+  // the MV3 race where the background worker is asleep at page-load time.
+  //
+  // Retries with backoff: on a fresh page load the content script may not be
+  // injected yet, or its initial extraction may still be running, so a single
+  // request can come back empty. We retry a few times over a few seconds.
+  const pullFromActiveTab = useCallback((attempt = 0) => {
+    const MAX_ATTEMPTS = 6;
+    const DELAY_MS = 700;
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      const tab = tabs[0];
+      if (!tab?.id || !tab.url?.includes('leetcode.com/problems/')) return;
+      chrome.tabs.sendMessage(tab.id, { type: 'REQUEST_PROBLEM_DATA' }, (response) => {
+        const notReady = chrome.runtime.lastError || !response?.success || !response?.data;
+        if (notReady) {
+          // Content script not injected yet or still extracting — retry.
+          if (attempt < MAX_ATTEMPTS) {
+            setTimeout(() => pullFromActiveTab(attempt + 1), DELAY_MS);
+          }
+          return;
+        }
+        applyProblem(response.data as ProblemContext);
+      });
+    });
+  }, [applyProblem]);
+
+  useEffect(() => {
+    // 1) Fast path: show whatever is cached in storage immediately.
+    chrome.storage.local.get('problemData', (result) => {
+      if (result.problemData) applyProblem(result.problemData as ProblemContext);
+    });
+
+    // 2) Reliable path: actively pull the current problem from the tab.
+    pullFromActiveTab();
+
+    // 3) Keep in sync when the user switches tabs or navigates.
+    const onActivated = () => pullFromActiveTab();
+    const onUpdated = (_tabId: number, info: { status?: string }, tab: chrome.tabs.Tab) => {
+      if (info.status === 'complete' && tab.active) pullFromActiveTab();
+    };
+    chrome.tabs.onActivated.addListener(onActivated);
+    chrome.tabs.onUpdated.addListener(onUpdated);
+
+    // 4) Still honor storage changes (push path) as a bonus.
+    const storageListener = (changes: Record<string, chrome.storage.StorageChange>) => {
+      if (changes.problemData?.newValue) applyProblem(changes.problemData.newValue as ProblemContext);
+    };
+    chrome.storage.onChanged.addListener(storageListener);
+
+    return () => {
+      chrome.tabs.onActivated.removeListener(onActivated);
+      chrome.tabs.onUpdated.removeListener(onUpdated);
+      chrome.storage.onChanged.removeListener(storageListener);
+    };
+  }, [applyProblem, pullFromActiveTab]);
 
   useEffect(() => {
     getSettings().then(s => {


### PR DESCRIPTION
Root cause: the bundled background.js uses ES module imports but the manifest declared a classic service worker, so the worker crashed on load and never registered. This broke the toolbar-icon side-panel open and the push-based data flow.

- Add 'type: module' to manifest background (the core fix)
- Enable side panel + openPanelOnActionClick on install/startup
- Switch to pull-based problem-data flow: side panel requests data from the content script with retry/backoff so title+difficulty display reliably on fresh load and navigation
- Add @types/node dev dependency to fix the build
- Remove default_popup so the icon opens the side panel
- Strip diagnostic console.logs from the content script
- Add Phase 1 spec (leetsage-phase1-gemini) and full learning guide
- Gitignore .kiro/settings/ (machine-specific MCP config)