### PR TITLE
docs: add career/interview/resume/design-decisions + learning roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Standard Chrome extension (Manifest V3) architecture:
 - **Background service worker** coordinates and persists state to `chrome.storage`.
 - Problem data flows via a **pull-based** model: the side panel requests the current problem from the content script when it's ready (robust against the MV3 service worker sleeping).
 
-See [`src/README.md`](src/README.md) for the source layout and [`docs/leetsage-learning-guide.md`](docs/leetsage-learning-guide.md) for a deep-dive on how everything works.
+See [`src/README.md`](src/README.md) for the source layout and [`docs/leetsage-learning-guide.md`](docs/leetsage-learning-guide.md) for a deep-dive on how everything works. For the *why* behind the architecture — plus interview prep, resume material, and the learning roadmap — see [`docs/career/`](docs/career/).
 
 ## Getting started
 

--- a/docs/career/DESIGN_DECISIONS.md
+++ b/docs/career/DESIGN_DECISIONS.md
@@ -1,0 +1,230 @@
+# LeetSage — Design Decisions (Architecture Decision Log)
+
+> A living record of *why* LeetSage is built the way it is. Every entry states the
+> decision, the alternatives considered, the tradeoff accepted, and what would
+> change the decision later. This doubles as engineering documentation **and** an
+> interview study sheet — being able to defend these choices is worth more than
+> the code itself.
+>
+> Companion docs: [INTERVIEW_PREP.md](./INTERVIEW_PREP.md) ·
+> [RESUME.md](./RESUME.md) · [LEARNING_ROADMAP.md](./LEARNING_ROADMAP.md) ·
+> code-level deep dive in [../leetsage-learning-guide.md](../leetsage-learning-guide.md)
+
+---
+
+## The one-paragraph summary (memorize this)
+
+LeetSage is a **client-only, bring-your-own-key (BYOK)** Chrome extension that
+coaches you through LeetCode problems without revealing full solutions. It has
+**no backend**: each user supplies their own Google Gemini API key, stored
+locally, and the browser calls Gemini directly. The product's core constraint —
+*never hand over the answer* — is enforced by a **multi-layer guardrail**
+(prompt-level rules plus a deterministic output filter). Every architectural
+choice flows from three goals: keep it **free**, keep it **safe** (both "no
+solutions" and "no central secret to leak"), and keep it **simple to operate**
+(zero infrastructure).
+
+---
+
+## ADR-001 — Bring-your-own-key (BYOK), not a managed key
+
+**Decision.** Each user pastes their own free Gemini API key into Settings. It is
+stored in `chrome.storage.local` on their machine and sent directly from their
+browser to Google. LeetSage never holds anyone's key.
+
+**Alternatives considered.**
+- *Managed key* (I hold one key, proxy all users' calls): would let users skip
+  setup, but requires a backend, makes me pay for everyone's usage, exposes me to
+  abuse/cost blowups, and centralizes a secret that becomes a breach target.
+- *OAuth into a provider*: heavier setup, still needs a backend to hold tokens.
+
+**Tradeoff accepted.** Users must do a one-time key setup (friction), and the key
+sits in plaintext in local extension storage (see ADR-002). In exchange: zero
+cost to me, zero central secret, zero server to run, and it scales to unlimited
+users for free.
+
+**What would change it.** If I wanted a frictionless "no setup" experience or
+managed billing, I'd introduce a backend proxy — which changes the entire
+cost/abuse/security calculus (see ADR-007 on scaling).
+
+---
+
+## ADR-002 — API key stored in `chrome.storage.local` (plaintext)
+
+**Decision.** The user's key lives in `chrome.storage.local`, unencrypted.
+
+**Why this is acceptable (not a defect).** A purely client-side app has no secure
+place to hide a secret *from the owner of the machine it runs on*. Any
+"encryption" key would also have to live on the same device, so it provides no
+real protection against a local attacker who already owns the box. This is the
+standard, accepted model for BYOK browser extensions.
+
+**Mitigations / honesty.**
+- The key is the *user's own* credential, scoped to their own free Gemini quota —
+  blast radius of exposure is their own account, not other users.
+- It is never transmitted anywhere except directly to Google's API over HTTPS.
+- README should tell users the key lives locally and to use a rotatable/scoped
+  key. (Follow-up item.)
+
+**What would change it.** Managed keys or cross-device sync would force a backend,
+at which point the secret moves server-side and gets real protection (vault,
+rotation, per-user scoping).
+
+---
+
+## ADR-003 — No backend (client-only architecture)
+
+**Decision.** There is no server. The extension is the whole product: content
+script + side panel (React) + background service worker, all running in the
+browser, calling Gemini directly.
+
+**Why.** The two things a backend usually buys — holding secrets and centralizing
+state — are things LeetSage deliberately *doesn't* want (BYOK removes the secret;
+per-user local storage removes the shared state). Without those needs, a backend
+is pure cost and operational burden.
+
+**Tradeoff accepted.** No server-side analytics, no managed keys, no cross-device
+sync, no server-side prompt updates (prompt changes ship with the extension).
+
+**What would change it.** Any feature requiring *shared* or *central* state:
+managed keys, cross-device progress sync, aggregate analytics/leaderboards, or
+remotely-updatable prompts. See [INTERVIEW_PREP.md](./INTERVIEW_PREP.md) "How do
+you scale with no backend?".
+
+---
+
+## ADR-004 — Multi-layer guardrail to never reveal full solutions
+
+**Decision.** Enforce the "teach, don't solve" constraint in **two layers**:
+1. **Prompt-level** (`src/services/prompts.ts`): system rules instruct the model
+   to give progressive hints, never complete implementations, for most actions.
+2. **Deterministic output filter** (`src/services/solution-filter.ts`): a
+   post-generation check that runs on the model's output and replaces it with a
+   "content filtered" message if it looks like a full answer.
+
+**How the filter actually works** (`filterResponse(content, actionType)`):
+- **Exempt actions.** `CHECK_APPROACH` and `UNDERSTAND_SOLUTION` are exempt —
+  their whole point is to discuss the user's *own* code, so solution-like content
+  is expected there.
+- **Layer A — phrase match.** Substring scan for solution-revealing language
+  ("here's the complete solution", "full implementation", etc.).
+- **Layer B — code-size + shape.** Extracts fenced code blocks; rejects any block
+  over `MAX_CODE_BLOCK_LINES` (14). A block over `MAX_SNIPPET_LINES` (8) that also
+  matches a "complete function" regex (def/function/method with a substantial
+  body) is rejected as a full implementation.
+- **Layer C — pseudocode heuristic.** `looksLikeFullPseudocode()` flags text
+  (fenced *or* prose) that combines ≥5 control-flow lines with a loop **and** a
+  branch **and** a result/return — the signature of "the whole algorithm spelled
+  out in words." Added after a real incident where the model returned pseudocode
+  that was a 1:1 of the solution.
+
+**Why two layers (defense in depth).** The prompt is a *soft* control — LLMs are
+non-deterministic and can be talked around. The filter is a *hard*,
+deterministic backstop that doesn't depend on the model complying. This is the
+2026-standard pattern: **never trust the model's compliance alone; add a
+deterministic check on the output.**
+
+**Tradeoff accepted.** Heuristics have false positives (a legitimately long
+explanation can trip the line limit) and false negatives (a clever paraphrase can
+slip through). The thresholds are tuned conservatively toward learning.
+
+**What would improve it.** An **eval suite** (see LEARNING_ROADMAP) to measure the
+filter's precision/recall against a labeled set, and an LLM-as-judge layer for the
+semantic "did this basically give the answer?" cases that regex can't catch.
+
+---
+
+## ADR-005 — Gemini via the OpenAI-compatible endpoint
+
+**Decision.** Call Gemini through its OpenAI-compatible Chat Completions endpoint
+(`.../v1beta/openai/chat/completions`) with `Bearer` auth, rather than the native
+Gemini SDK.
+
+**Why.**
+- **Free tier.** Gemini has a genuinely usable free tier — essential for a
+  zero-cost BYOK tool.
+- **Familiar, portable shape.** The OpenAI request/response format is the
+  lingua franca; using it means the provider is swappable later with minimal code
+  change (any OpenAI-compatible provider drops in).
+- **Streaming.** Supports token streaming for responsive UX.
+
+**Tradeoff accepted.** The compat layer may lag native Gemini features. Fine for
+chat-completion use.
+
+**Hard-won lesson.** Model names matter and drift. `gemini-2.5-*` names returned
+404 (deprecated); the working names were `gemini-3.5-flash-lite` / `gemini-3.5-flash`.
+A stale model name — *not* the key format — caused an earlier 404 debugging loop.
+**Always verify current model names against the provider docs before assuming.**
+
+---
+
+## ADR-006 — Manifest V3, pull-based problem-data flow
+
+**Decision.** Build as an MV3 extension. The side panel **pulls** problem data
+from the content script on demand (via a `REQUEST_PROBLEM_DATA` message with
+retry/backoff, plus a `chrome.scripting.executeScript` inject as a fallback),
+rather than relying on the content script to **push** it.
+
+**Why pull, not push.** MV3 replaced persistent background pages with **service
+workers that sleep** when idle. A push-only design silently drops data whenever
+the worker is asleep. Pull-with-retry is robust against that lifecycle.
+
+**Other MV3 gotchas encountered (real systems experience):**
+- The service worker needs `"type": "module"` in the manifest or it crashes
+  silently on ES-module imports.
+- Reading the user's code from the Monaco editor requires injecting into the
+  page's **MAIN world** (`world: 'MAIN'`), because `window.monaco` lives in the
+  page's JS context, which the isolated content script can't touch.
+- Session persistence keys on a **normalized** problem URL (`/problems/{slug}/`)
+  so that navigating to the submissions tab doesn't wipe the chat history.
+
+**What would change it.** Nothing near-term; MV3 is mandatory for the Chrome Web
+Store.
+
+---
+
+## ADR-007 — Free-tier guardrails (rate limiting, caps, kill switch)
+
+**Decision.** Client-side guardrails: per-minute rate limit, daily request cap,
+cooldown between requests, per-request token cap, request timeout, and a global
+kill switch — all user-adjustable.
+
+**Why.** Even with BYOK, runaway calls burn the user's free quota and cost them
+money if they've enabled billing. The guardrails make the tool safe-by-default and
+demonstrate **cost-control thinking** — a theme interviewers probe directly
+("how do you keep LLM costs bounded?").
+
+**Tradeoff accepted.** Client-side limits can be bypassed by a determined user
+editing storage — acceptable because the only person they'd hurt is themselves
+(their own key/quota). Server-side enforcement would need a backend.
+
+---
+
+## ADR-008 — Model tiering (Flash-Lite default, Flash optional)
+
+**Decision.** Default to `gemini-3.5-flash-lite` (cheapest/fastest), let users
+opt up to `gemini-3.5-flash` for harder explanations.
+
+**Why.** Most coaching actions (hints, breakdowns) don't need the strongest model.
+Defaulting to the cheap tier keeps latency low and free-tier usage sustainable;
+this is **model tiering / routing**, a named cost-optimization technique worth
+citing in interviews.
+
+---
+
+## Cross-cutting themes (the interview headline)
+
+| Theme | Where it shows up | Interview framing |
+|---|---|---|
+| Cost control | BYOK, guardrails, model tiering | "How do you keep LLM costs bounded?" |
+| Safety / output constraints | Multi-layer guardrail, solution-filter | "How do you stop the model doing X?" |
+| Security tradeoffs | BYOK, local key storage | "How do you secure users' keys?" |
+| Non-determinism | Deterministic filter over probabilistic model | "LLM output isn't reliable — how do you handle that?" |
+| Untrusted input | LeetCode page content flows into prompts | "Prompt injection — are you exposed?" |
+| Platform constraints | MV3 worker lifecycle, MAIN-world injection | "Tell me about a hard bug." |
+| Knowing when *not* to build | No backend until a feature needs one | "When would you add infrastructure?" |
+
+---
+
+*Maintained alongside the code. When a decision changes, add a new ADR or amend
+the existing one with a dated note — don't delete history.*

--- a/docs/career/INTERVIEW_PREP.md
+++ b/docs/career/INTERVIEW_PREP.md
@@ -1,0 +1,261 @@
+# LeetSage — Interview Prep
+
+> Your study sheet for defending this project in a 2026 software / AI engineering
+> interview. Each question has a **short answer** (say this first), a **deeper
+> follow-up** (when they push), and the **signal** it demonstrates. Practice
+> saying the short answers out loud until they're natural.
+>
+> Companion docs: [DESIGN_DECISIONS.md](./DESIGN_DECISIONS.md) ·
+> [RESUME.md](./RESUME.md) · [LEARNING_ROADMAP.md](./LEARNING_ROADMAP.md)
+
+---
+
+## How to use this doc
+
+1. Read the **60-second pitch** below until you can deliver it smoothly.
+2. Drill the **Core Q&A** — these are the questions this project *will* attract.
+3. Skim **General 2026 AI-engineering questions** — this project gives you a
+   concrete example to answer each with ("in LeetSage I did X...").
+4. Have a friend (or me — I can run mock interviews) ask from the **Mock
+   interview bank** and push back on your answers.
+
+---
+
+## The 60-second pitch
+
+> "LeetSage is a Chrome extension that coaches you through LeetCode problems
+> without giving away the answer. It's an AI learning tool: progressive hints,
+> problem breakdowns, and code analysis, all grounded in the specific problem
+> you're on. The interesting engineering is that it's **client-only and
+> bring-your-own-key** — no backend, each user brings a free Gemini key stored
+> locally, so it costs nothing to run and scales for free. The hard part was
+> enforcing the product's core rule — *never reveal the full solution* — which I
+> did with a **two-layer guardrail**: prompt instructions plus a deterministic
+> output filter that catches full implementations and pseudocode the model might
+> leak. I also handled Manifest V3 constraints, streaming responses, and
+> client-side cost guardrails."
+
+That hits: product clarity, an architectural tradeoff, a safety mechanism, and
+platform depth — in one paragraph.
+
+---
+
+## Core Q&A (this project will attract these)
+
+### Q1. "How do you secure different users' API keys?"
+
+**Short answer.** I don't hold them at all, and that's deliberate. It's
+bring-your-own-key: each user's Gemini key stays on their machine in
+`chrome.storage.local` and goes directly from their browser to Google. There's no
+server, so there's no central store to breach and no secret I'm liable for.
+
+**Deeper.** The tradeoff is the key sits in plaintext in local storage — but a
+client-only app can't hide a secret from the machine's own owner anyway, so any
+"encryption" would be theater (the decryption key lives on the same device). The
+key is the user's own credential scoped to their own free quota, so the blast
+radius of exposure is their account alone. If I needed to protect the key from the
+user, or offer managed keys, that *forces* a backend — which is a different
+security model (server-side vault, rotation, per-user scoping).
+
+**Signal.** Security judgment; knowing what a control actually protects against;
+understanding that architecture dictates the threat model.
+
+---
+
+### Q2. "You have no backend — how does this scale?"
+
+**Short answer.** It scales trivially and for free *because* there's no backend.
+Every user brings their own key and their own rate limits, so there's no shared
+resource to saturate, no bill that grows with users, and no single point of
+failure. It scales to a million users at zero marginal cost to me.
+
+**Deeper.** What *doesn't* scale in this design is anything needing shared state:
+managed keys, cross-device sync, aggregate analytics, leaderboards, or
+server-updatable prompts. The moment I want one of those, I add a backend, and I
+can describe it: an auth layer, a proxy that brokers or pools keys, server-side
+per-user quota enforcement, and cost controls (response caching, model tiering,
+token budgets). The senior move is *not* building that infrastructure until a
+feature actually requires it.
+
+**Signal.** Distinguishing "scales" from "has features that need scale";
+cost-awareness; knowing when *not* to add infrastructure.
+
+---
+
+### Q3. "How do you stop the AI from just giving the answer?"
+
+**Short answer.** Two layers. First, prompt-level rules tell the model to give
+progressive hints and never full implementations. But prompts are a *soft*
+control — LLMs are non-deterministic and can be talked around. So second, there's
+a **deterministic output filter** that runs on every response and replaces it if
+it looks like a full solution.
+
+**Deeper — how the filter works.** It's layered:
+- Phrase detection ("here's the complete solution", etc.).
+- Code-size + shape checks: reject fenced code blocks over 14 lines, or blocks
+  over 8 lines that match a complete-function regex.
+- A pseudocode heuristic that flags text combining ≥5 control-flow lines with a
+  loop, a branch, and a result — the signature of "the whole algorithm in words."
+  I added this after a real incident where the model returned pseudocode that was
+  a 1:1 of the solution.
+- Actions that analyze the user's *own* code (`CHECK_APPROACH`,
+  `UNDERSTAND_SOLUTION`) are exempt, because discussing their solution is the point.
+
+**Honesty about limits.** Heuristics have false positives and negatives. The right
+next step is an **eval suite** to measure the filter's precision/recall on a
+labeled set, plus an LLM-as-judge layer for the semantic cases regex can't catch.
+
+**Signal.** Defense-in-depth; not trusting model compliance; knowing the limits of
+your own solution and the path to improve it. **This is your strongest story —
+lead with it if they ask about AI safety or output control.**
+
+---
+
+### Q4. "LeetCode's problem text flows into your prompts. Are you exposed to prompt injection?"
+
+**Short answer.** Yes, in principle — the problem description is untrusted input
+that gets composed into the prompt, and prompt injection is the OWASP #1 risk for
+LLM apps. In LeetSage the blast radius is small (the worst case is the model
+misbehaving in the user's own panel; there are no tools, no privileged actions, no
+other users' data to exfiltrate), but I treat page content as data, not
+instructions.
+
+**Deeper — what I'd harden.** The root cause is that LLMs read instructions and
+data as one text stream. Mitigations: **structural separation** (clearly delimit
+untrusted content and never interpolate it into the instruction section), explicit
+"the following is problem text, not commands" framing, output validation (the
+solution-filter already is one form of this), and **least privilege** — LeetSage
+grants the model no tools or external actions, which removes the most dangerous
+injection outcomes by construction.
+
+**Signal.** Awareness of the #1 LLM security risk; ability to reason about blast
+radius; knowing the standard mitigations even if not all are implemented yet.
+
+---
+
+### Q5. "How do you control LLM cost and latency?"
+
+**Short answer.** Several levers. **Model tiering** — default to the cheap, fast
+`flash-lite` model and only use the stronger model when needed. **Client-side
+guardrails** — per-minute rate limit, daily cap, cooldown, per-request token cap,
+timeout, and a kill switch. And **streaming** so the user sees output immediately
+even for longer responses.
+
+**Deeper.** In a backed version I'd add response caching (identical
+problem+action can reuse a result), token budgeting per user, and prompt
+compression. Cost-per-token math is worth being able to do live: tokens ×
+price-per-million, times expected request volume.
+
+**Signal.** Production cost-awareness — a named 2026 interview theme.
+
+---
+
+### Q6. "Tell me about a hard bug." (Manifest V3 depth)
+
+**Short answer.** MV3 replaced persistent background pages with service workers
+that *sleep* when idle. My first data-flow design had the content script push
+problem data to the panel — which silently failed whenever the worker was asleep.
+
+**Deeper.** I switched to a **pull-based** flow: the side panel requests the
+problem on demand with retry/backoff, and falls back to injecting the content
+script via `chrome.scripting.executeScript` if there's no receiver. Two other MV3
+gotchas: the worker needs `"type": "module"` in the manifest or it crashes
+silently on ES imports; and reading the user's code from the Monaco editor
+requires injecting into the page's **MAIN world**, because `window.monaco` lives
+in the page's JS context that the isolated content script can't reach.
+
+**Signal.** Real platform systems experience; debugging non-obvious lifecycle
+issues; adapting architecture to platform constraints.
+
+---
+
+### Q7. "Why Gemini? Why the OpenAI-compatible endpoint?"
+
+**Short answer.** Gemini has a genuinely usable free tier, which is essential for a
+zero-cost BYOK tool. I use its OpenAI-compatible endpoint so the request shape is
+the industry-standard one — which means the provider is swappable later with
+minimal code change.
+
+**Deeper / lesson.** Model names drift and matter: `gemini-2.5-*` names 404'd
+(deprecated); the working ones were `gemini-3.5-flash-lite` / `-flash`. A stale
+model name, not the key, caused an early debugging loop — so I now verify model
+names against provider docs before assuming.
+
+**Signal.** Pragmatic provider choice; portability thinking; learning from a
+concrete mistake.
+
+---
+
+## General 2026 AI-engineering questions (use LeetSage as your example)
+
+These come up in AI/LLM interviews regardless of the project. For each, the goal
+is to answer generally **and** ground it in LeetSage.
+
+- **"What are evals and why do they matter?"** Evals measure whether an AI feature
+  actually works, instead of a "vibe check" on a few outputs. LLM-as-judge uses one
+  model to score another against a rubric; you validate the judge against a small
+  labeled set (it can reach ~85% human agreement but has position/verbosity/
+  self-preference biases). *LeetSage tie-in:* my solution-filter is a deterministic
+  eval target — I plan an eval suite that asserts the model never leaks a full
+  solution and hints stay progressive.
+- **"Structured output / function calling?"** Constraining the model to emit JSON
+  matching a schema, so downstream code can rely on it. *Tie-in:* LeetSage currently
+  parses freeform text; moving hints/complexity to schema'd JSON would make
+  rendering robust. (On the roadmap.)
+- **"RAG?"** Retrieval-augmented generation — fetch relevant context and put it in
+  the prompt instead of relying on model memory. *Tie-in:* the planned language
+  cheatsheet could be a small local retrieval layer (zero token cost).
+- **"Agents / agentic failure modes?"** Multi-step LLM systems that plan and act;
+  failure modes include loops, tool misuse, and cascading errors. *Tie-in:* the
+  planned progress-tracking feature (summarize a solved problem, categorize the
+  pattern, update notes) is a small agentic flow.
+- **"How do you handle non-determinism?"** Don't rely on exact outputs; validate
+  structurally, add deterministic guardrails, use evals to measure behavior over
+  many runs. *Tie-in:* the deterministic filter over a probabilistic model is
+  exactly this.
+- **"Hallucination mitigation?"** Grounding (give the model the real problem
+  text), constraining scope, and output validation.
+
+---
+
+## Behavioral / judgment questions
+
+- **"Why did you build this?"** Genuine: I use it for my own LeetCode practice, and
+  I wanted a tool that teaches instead of spoiling. (Authentic motivation reads
+  well.)
+- **"What would you do differently?"** Add evals and tests from the start; narrow
+  extension permissions earlier; instrument basic metrics so I could quote impact
+  numbers.
+- **"What are you most proud of?"** The guardrail — turning a fuzzy product promise
+  ("don't give the answer") into a concrete, layered, testable mechanism.
+- **"What's the biggest weakness right now?"** No automated tests/evals yet, and no
+  usage metrics — so I can describe behavior but not yet quantify it. I know exactly
+  what I'd measure and why.
+
+---
+
+## Mock interview bank (have someone ask these cold)
+
+**Warm-up:** Pitch LeetSage in 60 seconds. · What problem does it solve? · Who's
+the user?
+
+**Architecture:** Draw the components and how they communicate. · Why no backend? ·
+Walk me through what happens from clicking "Hint" to seeing text. · Where does
+state live?
+
+**AI-specific:** How do you stop it revealing solutions? · How would you test that
+it doesn't? · Design an eval for the guardrail. · Are you exposed to prompt
+injection? · How do you control cost?
+
+**Depth probes:** Why `chrome.storage.local` and not `sync`? · What breaks if the
+service worker sleeps mid-request? · How do you keep chat history per problem? ·
+Why the OpenAI-compat endpoint over the native SDK?
+
+**Stretch (system design):** "Now imagine 1M users and you want managed keys +
+cross-device sync + analytics. Design the backend." (Walk: auth, key-broker proxy,
+per-user quota, caching, model routing, cost controls, data store, privacy.)
+
+---
+
+*Update this as the project grows. When you add evals, tests, or metrics, add the
+numbers here — quantified answers beat qualitative ones every time.*

--- a/docs/career/LEARNING_ROADMAP.md
+++ b/docs/career/LEARNING_ROADMAP.md
@@ -1,0 +1,187 @@
+# LeetSage — Learning & Build Roadmap
+
+> The forward plan, ordered by **interview-value-per-effort**. Every item names
+> the AI-engineering skill it teaches, the resume/interview payoff, and a rough
+> effort estimate — so each thing you build also advances your job prep. This is
+> a *learning* roadmap first; features are the vehicle.
+>
+> Companion docs: [DESIGN_DECISIONS.md](./DESIGN_DECISIONS.md) ·
+> [INTERVIEW_PREP.md](./INTERVIEW_PREP.md) · [RESUME.md](./RESUME.md)
+> Feature specs live in [../../.kiro/specs/](../../.kiro/specs/).
+
+---
+
+## How to read this
+
+Each item is scored on two axes:
+- **Payoff** — how much it strengthens your 2026 AI-engineering resume/interview story.
+- **Effort** — rough build cost.
+
+Do **high-payoff / low-effort** first. The ordering below already reflects that.
+
+> ⚠️ Sequencing note carried over from project state: the **progress-tracking
+> export** feature should land *before* the "scope extension permissions" security
+> change, because that change requires removing/re-adding the extension, which
+> clears `chrome.storage.local` (your accumulated chat/history). Export first so
+> nothing is lost.
+
+---
+
+## Tier 1 — Do these first (highest payoff per effort)
+
+### 1. Eval suite for the solution-filter guardrail  ⭐ top priority
+**Skill:** LLM evals, LLM-as-judge, precision/recall thinking, non-determinism.
+**Why it's #1.** Evals are *the* hot 2026 AI-engineering skill and the way teams
+gate releases. This one project item simultaneously (a) hardens your core product
+promise, (b) unlocks your strongest resume bullet, and (c) produces the
+**quantified numbers** every other resume bullet currently lacks.
+**What to build.**
+- A labeled dataset: model responses paired with "leaks solution? yes/no".
+- **Deterministic evals** — assert `filterResponse` catches the known-bad cases and
+  passes the known-good ones (this is also just unit testing the filter).
+- **LLM-as-judge eval** — a second model scores "did this basically give away the
+  answer?" for the semantic cases regex can't catch. Validate the judge against
+  your labeled set; note its known biases (position, verbosity, self-preference).
+- Report catch-rate, false-positive rate, and hint-progression adherence.
+**Interview payoff.** "I designed evals that measure an AI safety constraint at
+scale, combining deterministic checks with a validated LLM-as-judge." That's a
+senior-sounding, true sentence.
+**Effort:** Medium. **Depends on:** nothing.
+
+### 2. Automated tests (Vitest) for pure logic
+**Skill:** engineering rigor, testing.
+**What to build.** Vitest on the stable, pure modules: `solution-filter`,
+`rate-limiter`, `stuck-timer`, and `normalizeProblemUrl`. (The filter tests overlap
+with the deterministic evals above — build them together.)
+**Why.** Signals rigor; protects the guardrail (core promise) and the
+session-persistence fix from regressions once strangers use it.
+**Interview payoff.** Answers "how do you know it works?" and "what's your testing
+approach?".
+**Effort:** Low–Medium. **Depends on:** nothing (pairs with #1).
+
+### 3. Instrument basic metrics
+**Skill:** production monitoring mindset, cost-awareness.
+**What to build.** Lightweight local counters: requests served, filter catch-rate,
+p50/p95 latency, avg tokens/request, estimated cost/request.
+**Why.** You can't quote impact you never measured. Even self-collected numbers
+turn qualitative resume bullets into quantified ones.
+**Interview payoff.** Fills the `[X]` placeholders in [RESUME.md](./RESUME.md).
+**Effort:** Low–Medium. **Depends on:** nothing.
+
+### 4. Scope extension permissions (security hardening)
+**Skill:** least-privilege, extension security.
+**What to build.** Narrow `host_permissions` from `*://*/*` to `leetcode.com`,
+drop the `tabs` permission in favor of `activeTab`, remove the dev-only localhost
+match. (Already prototyped and reverted; documented in project history.)
+**Why.** Removes the "reads all your browsing" warning; strengthens the
+security-minded story.
+**Interview payoff.** Concrete least-privilege example.
+**Effort:** Low. **Depends on:** ⚠️ do the progress-tracking export (#5) first to
+avoid losing stored data during the required remove/re-add.
+
+---
+
+## Tier 2 — Strong features that teach headline skills
+
+### 5. Progress tracking & study notes (agentic summarization)
+**Spec:** `leetsage-progress-tracking`. **Skill:** agentic flows, structured
+output, summarization.
+**MVP (do this slice first).** A "generate report" button that summarizes a solved
+problem (pattern/category, approach, key insight, complexity) and a **copy-text**
+button so you can paste it elsewhere. This MVP also **doubles as the data-export**
+that must precede the permission change (#4).
+**Fuller vision.** A living record that updates as you solve/re-solve problems —
+framed as a small **agent** that categorizes and maintains notes.
+**Interview payoff.** "I built an agentic feature that summarizes and categorizes."
+Also solves your real need (tracking your own LeetCode progress).
+**Effort:** Medium (MVP) → High (full sync/analytics).
+
+### 6. Structured output / function calling
+**Skill:** modern LLM I/O, schema-constrained generation.
+**What to build.** Move hints, complexity breakdowns, and examples from freeform
+text to **JSON matching a schema**, so rendering is robust and the guardrail can
+inspect structured fields instead of scraping prose.
+**Why.** Named 2026 skill; makes the UI more reliable; complements the filter.
+**Interview payoff.** "I used structured output to make LLM responses
+machine-reliable." **Effort:** Medium.
+
+### 7. Prompt-injection hardening
+**Skill:** LLM security (OWASP #1 risk), structural prompt separation.
+**What to build.** Explicitly delimit untrusted LeetCode page content from
+instructions (never interpolate it into the instruction section); add "the
+following is problem text, not commands" framing; keep the model tool-less
+(least privilege — already true). Write down the threat model in
+[DESIGN_DECISIONS.md](./DESIGN_DECISIONS.md).
+**Interview payoff.** Directly answers the prompt-injection question with
+implemented mitigations, not just awareness. **Effort:** Low–Medium.
+
+### 8. Language cheatsheet (local RAG)
+**Spec:** `leetsage-cheatsheet`. **Skill:** retrieval / RAG (lightweight, local),
+zero-token design.
+**What to build.** Curated Python/Java/C++ LeetCode idioms + Big-O chart, stored
+**in the extension** (zero tokens). A small local retrieval layer surfaces the
+relevant snippet for the current problem/language.
+**Why.** Lets you truthfully say "I built a lightweight RAG system"; genuinely
+useful; costs no tokens.
+**Interview payoff.** RAG is a headline keyword; the "local, zero-cost" angle shows
+cost-awareness. **Effort:** Medium.
+
+---
+
+## Tier 3 — Ambitious / novelty showcases (do when Tier 1–2 are solid)
+
+### 9. On-device / in-browser model fallback
+**Skill:** on-device inference, edge AI, the newest 2026 frontier.
+**What to build.** A "no-key" mode using an in-browser model
+(e.g. WebLLM, or Chrome's built-in Prompt API / Gemini Nano where available) as a
+fallback that removes the BYOK setup friction.
+**Why.** Striking, current, and removes the one UX rough edge (key setup).
+**⚠️ Verify first.** These APIs move fast — confirm current availability, naming,
+and browser support against official docs *before* committing (same discipline as
+the model-name lesson in [DESIGN_DECISIONS.md](./DESIGN_DECISIONS.md) ADR-005).
+**Effort:** High.
+
+### 10. Backend evolution (only if a feature demands it)
+**Skill:** GenAI system design — the system-design-interview centerpiece.
+**When.** Only when you want managed keys, cross-device sync, aggregate analytics,
+or server-updatable prompts (see [DESIGN_DECISIONS.md](./DESIGN_DECISIONS.md)
+ADR-003/007). Until then, *not building it* is the correct, senior choice.
+**What it would include.** Auth, a key-broker proxy, server-side per-user quota,
+response caching, model routing, a data store, and privacy handling.
+**Interview payoff.** Even *designing this on a whiteboard* (without building it)
+is exactly the GenAI system-design interview. Rehearse it either way — it's in the
+[INTERVIEW_PREP.md](./INTERVIEW_PREP.md) "Stretch" section.
+**Effort:** High.
+
+---
+
+## Other deferred specs (parked, lower priority)
+
+- `leetsage-pseudocode-mode` — a lightweight "plan your approach" playground with
+  limited, token-conscious feedback.
+- `leetsage-phase2-struggle-first` — deeper hints unlock only after the user
+  explains their reasoning.
+- `leetsage-phase3-analytics` — hints used, submission outcomes, "problems to
+  revisit."
+
+---
+
+## Suggested sequence (the TL;DR)
+
+1. **Progress-tracking MVP** (#5 slice) — needed as data-export before #4, and it's
+   your first agentic feature.
+2. **Eval suite + tests + metrics** (#1–3, built together) — the biggest
+   resume/interview unlock; produces your numbers.
+3. **Scope permissions** (#4) — quick security win, safe to do now that data is
+   exportable.
+4. **Structured output** (#6) then **prompt-injection hardening** (#7) — reliability
+   + security depth.
+5. **Cheatsheet / RAG** (#8), then Tier 3 stretch items.
+
+At each step, backfill numbers into [RESUME.md](./RESUME.md) and new Q&A into
+[INTERVIEW_PREP.md](./INTERVIEW_PREP.md). The docs are living — grow them with the code.
+
+---
+
+*This roadmap optimizes for learning + interview readiness, not feature count.
+When priorities shift, re-order by the payoff/effort lens rather than by novelty.*

--- a/docs/career/README.md
+++ b/docs/career/README.md
@@ -1,0 +1,19 @@
+# LeetSage — Career & Engineering Docs
+
+Documentation that captures the *why* behind LeetSage and turns the project into
+interview + resume material for a 2026 software / AI engineering job search.
+Grounded in current hiring-team expectations (evals, production LLM features,
+cost-awareness, AI security) and in the project's actual implementation.
+
+| Doc | What it's for |
+|---|---|
+| [DESIGN_DECISIONS.md](./DESIGN_DECISIONS.md) | Architecture decision log (ADRs): BYOK, no backend, the multi-layer guardrail, MV3, Gemini, cost controls — decision, alternatives, tradeoff, and what would change it. Doubles as an interview study sheet. |
+| [INTERVIEW_PREP.md](./INTERVIEW_PREP.md) | The 60-second pitch, core Q&A (key security, scaling, guardrails, prompt injection, cost, MV3), general 2026 AI-engineering questions grounded in LeetSage, and a mock-interview bank. |
+| [RESUME.md](./RESUME.md) | Ready-to-adapt resume bullets (three flavors), project blurbs, ATS keywords, and an honest gap analysis that doubles as a build priority list. |
+| [LEARNING_ROADMAP.md](./LEARNING_ROADMAP.md) | Forward plan ordered by interview-value-per-effort: evals, tests, metrics, structured output, prompt-injection hardening, RAG cheatsheet, on-device models, agentic progress-tracking. |
+
+For code-level understanding, see the [deep-dive learning guide](../leetsage-learning-guide.md).
+
+**Maintenance:** these are living documents. As the project grows — especially as
+evals, tests, and metrics land — backfill quantified numbers into `RESUME.md` and
+new Q&A into `INTERVIEW_PREP.md`.

--- a/docs/career/RESUME.md
+++ b/docs/career/RESUME.md
@@ -1,0 +1,156 @@
+# LeetSage — Resume Material
+
+> Ready-to-adapt resume bullets, a project blurb, and an honest gap analysis of
+> what to build before this reads as "AI Engineer" strong. Grounded in what
+> 2026 hiring teams actually screen for.
+>
+> Companion docs: [DESIGN_DECISIONS.md](./DESIGN_DECISIONS.md) ·
+> [INTERVIEW_PREP.md](./INTERVIEW_PREP.md) · [LEARNING_ROADMAP.md](./LEARNING_ROADMAP.md)
+
+---
+
+## What 2026 hiring teams screen for (why these bullets are shaped this way)
+
+Distilled from current AI/ML/LLM-engineer resume guidance
+([techiecv](https://www.techiecv.com/resume-guides/ai-engineer-resume),
+[huntr](https://huntr.co/resume-examples/ai-engineer),
+[interviewquery](https://www.interviewquery.com/p/ai-engineer-resume),
+[hireflow](https://hireflow.net/resume-examples/llm-engineer)) —
+*content rephrased for licensing compliance*:
+
+- **Shipped features with real users beat tutorials/notebooks.** A prompt notebook
+  on GitHub stalls before screening; a feature real people use gets read.
+- **Lead bullets with action verbs + measurable impact** (latency, cost, accuracy,
+  usage). Numbers > adjectives.
+- **Name the stack and the tools** so it matches the job posting and passes ATS
+  keyword scans.
+- **Show engineering rigor**, not just model calls — testing, evals, monitoring,
+  tradeoffs.
+- By 2026 market definition, if you've shipped an LLM-powered feature you can
+  legitimately use the "AI Engineer" framing.
+
+LeetSage fits the "shipped, real-user, real-tradeoffs" mold. Its current gap is
+**quantified impact** and **rigor artifacts** (tests/evals/metrics) — see the gap
+analysis below, which doubles as your build priority list.
+
+---
+
+## Project blurb (portfolio / LinkedIn / resume header)
+
+**Short (one line):**
+> LeetSage — a client-only Chrome extension that coaches LeetCode users with AI
+> hints and code analysis while enforcing a "never reveal the solution" guardrail.
+
+**Medium (portfolio):**
+> LeetSage is an AI learning coach for LeetCode, built as a bring-your-own-key
+> Chrome extension (Manifest V3, React + TypeScript). It streams Google Gemini
+> responses to deliver progressive hints, problem breakdowns, and pre-submission
+> code analysis — deliberately withholding full solutions via a two-layer
+> guardrail (prompt rules + a deterministic output filter). Zero backend, zero
+> hosting cost, and it scales for free because every user brings their own key.
+
+---
+
+## Resume bullets — three flavors
+
+Pick 2–4 depending on space. Swap in real numbers as soon as you have them
+(marked `[X]`). Verbs first, impact where possible.
+
+### Flavor A — concise (2 bullets, for a packed resume)
+
+- Built **LeetSage**, a Manifest V3 Chrome extension (React/TypeScript) that
+  streams Google Gemini responses to coach LeetCode users, using a **client-only,
+  bring-your-own-key** design that runs at **zero backend cost** and scales to
+  unlimited users.
+- Enforced a "never reveal the full solution" product constraint with a
+  **two-layer AI guardrail** — prompt-level rules plus a **deterministic output
+  filter** that blocks complete implementations and full-algorithm pseudocode.
+
+### Flavor B — detailed (4 bullets, dedicated project section)
+
+- Designed and shipped **LeetSage**, an AI coaching Chrome extension (Manifest V3,
+  React 19, TypeScript, Tailwind, Vite) integrating **Google Gemini** via its
+  OpenAI-compatible streaming API for real-time hints, breakdowns, and code analysis.
+- Architected a **client-only, bring-your-own-key** system with **no backend**,
+  eliminating hosting cost and centralized-secret risk — a deliberate
+  cost/security tradeoff — while enabling free, unlimited-user scaling.
+- Implemented a **multi-layer AI safety guardrail** enforcing a strict
+  "no full solutions" policy: system-prompt rules plus a deterministic post-generation
+  filter (phrase, code-size/shape, and full-pseudocode heuristics) that intercepts
+  solution leakage the model would otherwise produce.
+- Built **client-side cost/abuse guardrails** (rate limiting, daily caps,
+  cooldowns, token limits, timeout, kill switch) and **model tiering** (flash-lite
+  default) to keep latency low and free-tier usage sustainable.
+
+### Flavor C — AI-forward (leads with the AI-engineering signal)
+
+- Shipped a production **LLM-powered** learning feature (Google Gemini, streaming)
+  used on live LeetCode problems, applying **prompt engineering**, **output
+  validation**, and **model tiering** for cost control.
+- Engineered **defense-in-depth output guardrails** over a non-deterministic model
+  — a deterministic filter that enforces product constraints the prompt alone can't
+  guarantee — and scoped the design against **prompt-injection** risk (untrusted
+  page content, least-privilege, no tool access).
+- Made and documented core **AI system-design tradeoffs** (bring-your-own-key vs.
+  managed backend; client-only vs. server) with a written decision log and an
+  articulated scaling path.
+
+> Tip: keep one bullet that signals *rigor* (guardrails/validation) and one that
+> signals *judgment* (tradeoffs) — those two separate you from "called an API"
+> resumes.
+
+---
+
+## Skills-section keywords (ATS)
+
+Only list what you can defend. Currently truthful for LeetSage:
+
+`LLM integration` · `Google Gemini` · `prompt engineering` · `streaming responses`
+· `AI output guardrails` · `Chrome Extension (Manifest V3)` · `React` ·
+`TypeScript` · `Tailwind CSS` · `Vite` · `client-side architecture` ·
+`cost optimization / rate limiting`
+
+Add once built: `LLM evals` · `LLM-as-judge` · `structured output / function
+calling` · `RAG` · `unit testing (Vitest)` · `prompt-injection mitigation`.
+
+---
+
+## Honest gap analysis (= your build priority list)
+
+What separates the current project from a top-tier "AI Engineer" resume artifact,
+ordered by resume-value-per-effort. Each maps to
+[LEARNING_ROADMAP.md](./LEARNING_ROADMAP.md).
+
+| Gap | Why it matters on a resume | Fix | Effort |
+|---|---|---|---|
+| **No evals** | "I wrote evals for my LLM feature" is a top 2026 signal; it also proves the guardrail works | Eval suite for the solution-filter (deterministic + LLM-as-judge) | Medium |
+| **No quantified impact** | Resumes reward numbers; you currently have none | Instrument basics: requests handled, filter catch-rate, p50/p95 latency, tokens/request | Low–Med |
+| **No automated tests** | Signals engineering rigor | Vitest on filter, rate-limiter, URL normalization | Low–Med |
+| **No structured output** | Named modern-LLM-I/O skill | Move hints/complexity to JSON schema output | Medium |
+| **Broad permissions** | Reviewers/users notice; weakens "security-minded" claim | Scope `host_permissions` to leetcode.com (already staged, deferred) | Low |
+| **No RAG/agentic element** | Both are headline 2026 keywords | Cheatsheet (local RAG) or agentic progress-tracking | Med–High |
+
+**The single highest-leverage move:** build the **eval suite for the guardrail.**
+It hardens the core product promise *and* unlocks the strongest resume bullet
+("designed evals that measure an AI safety constraint at scale") *and* gives you
+the quantified numbers every other bullet is missing.
+
+---
+
+## Numbers to start capturing now
+
+You can't quote impact you never measured. Even rough, self-collected numbers help:
+
+- Requests served / problems coached (your own usage counts).
+- Solution-filter **catch rate** and false-positive rate (needs the eval set).
+- Median + p95 **response latency**.
+- Average **tokens per request** and estimated **cost per request** (even though
+  it's the user's free quota — the math shows cost-awareness).
+- Hint-progression adherence (does level 1 stay conceptual?).
+
+Log these as you build the eval suite, then backfill the `[X]` placeholders above.
+
+---
+
+*Revisit this doc right before you apply so bullets match the specific posting's
+language. Ask me to tailor a version to a job description any time.*


### PR DESCRIPTION
Capture the "why" behind LeetSage and turn the project into durable interview and resume material for a 2026 software / AI engineering job search. All new docs live under docs/career/ and are cross-linked; the main README now points to them. Documentation only — no code changes.

Grounded in two things so nothing is invented:
  1. Current 2026 hiring-team expectations (researched): evals as the way teams gate releases, production LLM features with measurable impact over tutorials/notebooks, cost-per-token awareness, and AI security (OWASP prompt-injection). Sourced material is paraphrased for licensing compliance.
  2. LeetSage's actual implementation (verified against the code, e.g. the exact solution-filter layers and thresholds), not assumptions.

New files:

- docs/career/README.md Index of the career docs with a one-line purpose for each.

- docs/career/DESIGN_DECISIONS.md Architecture decision log (8 ADRs): bring-your-own-key, plaintext local key storage, no backend, the multi-layer solution guardrail (with the real filter layers/thresholds documented), Gemini via the OpenAI-compatible endpoint + the model-name lesson, Manifest V3 pull-based data flow + gotchas, client-side cost guardrails, and model tiering. Each entry: decision, alternatives, tradeoff accepted, and what would change it. Closes with a cross-cutting themes table mapping each choice to its interview angle.

- docs/career/INTERVIEW_PREP.md A 60-second pitch; seven core Q&A (key security, scaling with no backend, the guardrail, prompt injection, cost/latency, the MV3 hard bug, why Gemini) each with a short answer, a deeper follow-up, and the signal it demonstrates; general 2026 AI-engineering questions (evals, structured output, RAG, agents, non-determinism, hallucination) grounded in LeetSage examples; behavioral questions; and a mock-interview bank.

- docs/career/RESUME.md What 2026 teams screen for (with cited sources), short/medium project blurbs, three resume-bullet flavors (concise, detailed, AI-forward) with placeholders for numbers, an ATS keyword list, an honest gap analysis that doubles as a build priority list, and a list of metrics to start capturing.

- docs/career/LEARNING_ROADMAP.md Forward plan ordered by interview-value-per-effort across three tiers. Tier 1: eval suite for the guardrail (top priority), tests, metrics, permission scoping. Tier 2: agentic progress-tracking, structured output, prompt-injection hardening, RAG cheatsheet. Tier 3: on-device model fallback, backend evolution. Preserves the critical sequencing note that the progress-tracking export must land before the permission change (which clears local storage).

Modified:

- README.md Added a pointer from the "How it works" section to docs/career/.